### PR TITLE
Support session replication for user classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .idea/libraries
 dependency-reduced-pom.xml
 target
+.classpath
+.project
+.settings

--- a/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
+++ b/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
@@ -16,16 +16,17 @@
 
 package com.gopivotal.manager;
 
-import org.apache.catalina.Manager;
-import org.apache.catalina.Session;
-import org.apache.catalina.session.StandardSession;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+
+import org.apache.catalina.Manager;
+import org.apache.catalina.Session;
+import org.apache.catalina.session.StandardSession;
 
 /**
  * Utilities for serializing and deserializing {@link Session}s
@@ -61,7 +62,19 @@ public final class SessionSerializationUtils {
 
         try {
             bytes = new ByteArrayInputStream(session);
-            in = new ObjectInputStream(bytes);
+            in = new ObjectInputStream(bytes) {
+
+         
+              @Override
+              protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+                try {
+                  return Class.forName(desc.getName(), false, Thread.currentThread().getContextClassLoader());
+                } catch (ClassNotFoundException cnfe) {
+                  return super.resolveClass(desc);
+                }
+              }
+              
+            };
 
             StandardSession standardSession = (StandardSession) this.manager.createEmptySession();
             standardSession.readObjectData(in);
@@ -110,4 +123,5 @@ public final class SessionSerializationUtils {
         }
     }
 
+    
 }

--- a/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
+++ b/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
@@ -63,8 +63,6 @@ public final class SessionSerializationUtils {
         try {
             bytes = new ByteArrayInputStream(session);
             in = new ObjectInputStream(bytes) {
-
-         
               @Override
               protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
                 try {
@@ -73,7 +71,6 @@ public final class SessionSerializationUtils {
                   return super.resolveClass(desc);
                 }
               }
-              
             };
 
             StandardSession standardSession = (StandardSession) this.manager.createEmptySession();

--- a/common/src/test/java/com/gopivotal/manager/SampleSessionObject.java
+++ b/common/src/test/java/com/gopivotal/manager/SampleSessionObject.java
@@ -1,0 +1,27 @@
+package com.gopivotal.manager;
+
+import java.io.Serializable;
+
+public class SampleSessionObject implements Serializable {
+  private static final long serialVersionUID = -7695256507142362389L;
+
+  private String sampleField;
+  
+  private transient long nonSerializableField;
+
+  public String getSampleField() {
+    return sampleField;
+  }
+
+  public void setSampleField(String sampleField) {
+    this.sampleField = sampleField;
+  }
+
+  public long getNonSerializableField() {
+    return nonSerializableField;
+  }
+
+  public void setNonSerializableField(long nonSerializableField) {
+    this.nonSerializableField = nonSerializableField;
+  }
+}

--- a/common/src/test/java/com/gopivotal/manager/SessionSerializationUtilsTest.java
+++ b/common/src/test/java/com/gopivotal/manager/SessionSerializationUtilsTest.java
@@ -16,6 +16,12 @@
 
 package com.gopivotal.manager;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+
 import org.apache.catalina.Context;
 import org.apache.catalina.Manager;
 import org.apache.catalina.Session;
@@ -23,11 +29,6 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardManager;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public final class SessionSerializationUtilsTest {
 
@@ -47,10 +48,20 @@ public final class SessionSerializationUtilsTest {
         Session initial = this.manager.createEmptySession();
         initial.setValid(true);
         initial.getSession().setAttribute("test-key", "test-value");
-
+        
+        SampleSessionObject obj = new SampleSessionObject();
+        obj.setSampleField("field-set");
+        obj.setNonSerializableField(40L);
+        
+        initial.getSession().setAttribute("test-key-2", obj);
+        
         Session result = this.sessionSerializationUtils.deserialize(this.sessionSerializationUtils.serialize(initial));
 
         assertEquals("test-value", result.getSession().getAttribute("test-key"));
+        
+        SampleSessionObject obj2 = (SampleSessionObject) result.getSession().getAttribute("test-key-2");
+        assertEquals("field-set", obj2.getSampleField());
+        assertNotEquals(40L, obj2.getNonSerializableField());
     }
 
     @Test


### PR DESCRIPTION
Force deserialization to use current Thread classloader. Verified working on Java 8 + Tomcat 7 and Java 8 + Tomcat 8.

Resolves issue https://github.com/cloudfoundry/java-buildpack/issues/138. I understand it's low priority but we have a client trying to migrate legacy code on to the Cloud Foundry platform and this is a blocker for them.