### PR TITLE
Cleanup formatting, use more modern Java, fix serialization

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -11,6 +11,12 @@
         </XML>
         <codeStyleSettings language="JAVA">
           <arrangement>
+            <groups>
+              <group>
+                <type>GETTERS_AND_SETTERS</type>
+                <order>KEEP</order>
+              </group>
+            </groups>
             <rules>
               <rule>
                 <match>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -27,8 +27,8 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="common" target="1.6" />
-      <module name="redis-store" target="1.6" />
+      <module name="common" target="1.7" />
+      <module name="redis-store" target="1.7" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,5 @@
 <component name="CopyrightManager">
-  <settings default="Apache License, Version 2.0" />
+  <settings default="Apache License, Version 2.0">
+    <module2copyright />
+  </settings>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="DaemonCodeAnalyzer">
+    <disable_hints />
+  </component>
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
@@ -10,8 +13,91 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
+  </component>
+  <component name="RunManager">
+    <configuration default="true" type="Remote" factoryName="Remote">
+      <option name="USE_SOCKET_TRANSPORT" value="true" />
+      <option name="SERVER_MODE" value="false" />
+      <option name="SHMEM_ADDRESS" value="javadebug" />
+      <option name="HOST" value="localhost" />
+      <option name="PORT" value="5005" />
+      <method />
+    </configuration>
+    <configuration default="true" type="Applet" factoryName="Applet">
+      <module name="" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="HTML_FILE_NAME" />
+      <option name="HTML_USED" value="false" />
+      <option name="WIDTH" value="400" />
+      <option name="HEIGHT" value="300" />
+      <option name="POLICY_FILE" value="$APPLICATION_HOME_DIR$/bin/appletviewer.policy" />
+      <option name="VM_PARAMETERS" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <method />
+    </configuration>
+    <configuration default="true" type="Application" factoryName="Application">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="JUnit" factoryName="JUnit">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="moduleWithDependencies" />
+      </option>
+      <envs />
+      <patterns />
+      <method />
+    </configuration>
+    <list size="0" />
+    <configuration name="&lt;template&gt;" type="TestNG" default="true" selected="false">
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    </configuration>
+    <configuration name="&lt;template&gt;" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" default="true" selected="false">
+      <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+    </configuration>
+    <configuration name="&lt;template&gt;" type="WebApp" default="true" selected="false">
+      <Host>localhost</Host>
+      <Port>5050</Port>
+    </configuration>
   </component>
 </project>
 

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ script: |
     mvn test
   fi
 jdk:
-- openjdk6
-- openjdk7
-- oraclejdk8
+  - openjdk7
+  - oraclejdk8
 env:
   global:
   - secure: NLOleRANVTErubOCrf3AnljVYxzrz3Os5atObx4cc1J10JUszNYY0QhNiv+2rlK96fHdER7fkf+s+FnaQcisDDUSFMZgzNAdlFvruPnwBBw/3qHLGix0UiTLP/jc6nWQK77hFwsprHvmVdlCMymHQpm9Gw917rTg21kOEM50w98= # ARTIFACTORY_USERNAME
@@ -26,12 +25,10 @@ env:
   - QUICK_BUILD=true
 matrix:
   exclude:
-  - jdk: openjdk6
-    env: RELEASE_BUILD=true
-  - jdk: openjdk6
-  - jdk: oraclejdk8
-    env: RELEASE_BUILD=true
-  - jdk: oraclejdk8
+    - jdk: oraclejdk8
+      env: RELEASE_BUILD=true
+    - jdk: oraclejdk8
+      env: SONAR_BUILD=true
 notifications:
   slack:
     secure: KNl/I6kawYri8MgYLMH0QYaexTmXu3MuK6vp8JOU1K5euSQMEwJgjRkBV8Xtc4+X21vht93PWBYkgRmK4EjO2n+QlFcNV9jKmJK/Glf1euUxvgJIeyu+UelkXDrK6cwGjuyDkwBTuD2s5zuofufuOqiq5lIay/+4BpM2CDToAMA=

--- a/common/common.iml
+++ b/common/common.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
+++ b/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
@@ -24,6 +24,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 
+import org.apache.catalina.Context;
+import org.apache.catalina.Globals;
 import org.apache.catalina.Manager;
 import org.apache.catalina.Session;
 import org.apache.catalina.session.StandardSession;
@@ -59,6 +61,8 @@ public final class SessionSerializationUtils {
 
         ByteArrayInputStream bytes = null;
         ObjectInputStream in = null;
+        Context context = this.manager.getContext();
+        ClassLoader oldThreadContextCL = context.bind(Globals.IS_SECURITY_ENABLED, null);
 
         try {
             bytes = new ByteArrayInputStream(session);
@@ -79,6 +83,7 @@ public final class SessionSerializationUtils {
             return standardSession;
         } finally {
             closeQuietly(in, bytes);
+            context.unbind(Globals.IS_SECURITY_ENABLED, oldThreadContextCL);
         }
     }
 

--- a/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
+++ b/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
@@ -16,16 +16,17 @@
 
 package com.gopivotal.manager;
 
-import org.apache.catalina.Manager;
-import org.apache.catalina.Session;
-import org.apache.catalina.session.StandardSession;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+
+import org.apache.catalina.Manager;
+import org.apache.catalina.Session;
+import org.apache.catalina.session.StandardSession;
 
 /**
  * Utilities for serializing and deserializing {@link Session}s
@@ -61,7 +62,16 @@ public final class SessionSerializationUtils {
 
         try {
             bytes = new ByteArrayInputStream(session);
-            in = new ObjectInputStream(bytes);
+            in = new ObjectInputStream(bytes) {
+                @Override
+                protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+                    try {
+                        return Class.forName(desc.getName(), false, Thread.currentThread().getContextClassLoader());
+                    } catch (ClassNotFoundException cnfe) {
+                        return super.resolveClass(desc);
+                    }
+                }
+            };
 
             StandardSession standardSession = (StandardSession) this.manager.createEmptySession();
             standardSession.readObjectData(in);
@@ -109,5 +119,4 @@ public final class SessionSerializationUtils {
             }
         }
     }
-
 }

--- a/common/src/main/java/com/gopivotal/manager/StandardLifecycleSupport.java
+++ b/common/src/main/java/com/gopivotal/manager/StandardLifecycleSupport.java
@@ -28,7 +28,7 @@ import static java.util.logging.Level.WARNING;
 
 final class StandardLifecycleSupport implements LifecycleSupport {
 
-    private final List<LifecycleListener> lifecycleListeners = new ArrayList<LifecycleListener>();
+    private final List<LifecycleListener> lifecycleListeners = new ArrayList<>();
 
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 

--- a/common/src/main/java/com/gopivotal/manager/StandardPropertyChangeSupport.java
+++ b/common/src/main/java/com/gopivotal/manager/StandardPropertyChangeSupport.java
@@ -34,7 +34,7 @@ public final class StandardPropertyChangeSupport implements PropertyChangeSuppor
 
     private final Object monitor = new Object();
 
-    private final List<PropertyChangeListener> propertyChangeListeners = new ArrayList<PropertyChangeListener>();
+    private final List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
 
     private final Object source;
 

--- a/common/src/test/java/com/gopivotal/manager/SampleSessionObject.java
+++ b/common/src/test/java/com/gopivotal/manager/SampleSessionObject.java
@@ -1,0 +1,27 @@
+package com.gopivotal.manager;
+
+import java.io.Serializable;
+
+public class SampleSessionObject implements Serializable {
+  private static final long serialVersionUID = -7695256507142362389L;
+
+  private String sampleField;
+
+  private transient long nonSerializableField;
+
+  public String getSampleField() {
+    return sampleField;
+  }
+
+  public void setSampleField(String sampleField) {
+    this.sampleField = sampleField;
+  }
+
+  public long getNonSerializableField() {
+    return nonSerializableField;
+  }
+
+  public void setNonSerializableField(long nonSerializableField) {
+    this.nonSerializableField = nonSerializableField;
+  }
+}

--- a/common/src/test/java/com/gopivotal/manager/SessionSerializationUtilsTest.java
+++ b/common/src/test/java/com/gopivotal/manager/SessionSerializationUtilsTest.java
@@ -16,6 +16,12 @@
 
 package com.gopivotal.manager;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+
 import org.apache.catalina.Context;
 import org.apache.catalina.Manager;
 import org.apache.catalina.Session;
@@ -23,11 +29,6 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardManager;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public final class SessionSerializationUtilsTest {
 
@@ -48,9 +49,19 @@ public final class SessionSerializationUtilsTest {
         initial.setValid(true);
         initial.getSession().setAttribute("test-key", "test-value");
 
+        SampleSessionObject obj = new SampleSessionObject();
+        obj.setSampleField("field-set");
+        obj.setNonSerializableField(40L);
+
+        initial.getSession().setAttribute("test-key-2", obj);
+
         Session result = this.sessionSerializationUtils.deserialize(this.sessionSerializationUtils.serialize(initial));
 
         assertEquals("test-value", result.getSession().getAttribute("test-key"));
+
+        SampleSessionObject obj2 = (SampleSessionObject) result.getSession().getAttribute("test-key-2");
+        assertEquals("field-set", obj2.getSampleField());
+        assertNotEquals(40L, obj2.getNonSerializableField());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/redis-store/redis-store.iml
+++ b/redis-store/redis-store.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/redis-store/src/main/java/com/gopivotal/manager/redis/RedisStore.java
+++ b/redis-store/src/main/java/com/gopivotal/manager/redis/RedisStore.java
@@ -51,33 +51,19 @@ import static java.util.logging.Level.SEVERE;
 public final class RedisStore extends AbstractLifecycle implements RedisStoreManagement, Store {
 
     private static final String SESSIONS_KEY = "sessions";
-
     private final JmxSupport jmxSupport;
-
     private final LockTemplate lockTemplate = new LockTemplate();
-
     private final Logger logger = Logger.getLogger(this.getClass().getName());
-
     private final PropertyChangeSupport propertyChangeSupport;
-
     private volatile int connectionPoolSize = GenericKeyedObjectPoolConfig.DEFAULT_MAX_TOTAL;
-
     private volatile int database = Protocol.DEFAULT_DATABASE;
-
     private volatile String host = "localhost";
-
     private volatile JedisPool jedisPool;
-
     private volatile JedisTemplate jedisTemplate;
-
     private volatile Manager manager;
-
     private volatile String password;
-
     private volatile int port = Protocol.DEFAULT_PORT;
-
     private volatile SessionSerializationUtils sessionSerializationUtils;
-
     private volatile int timeout = Protocol.DEFAULT_TIMEOUT;
 
     /**
@@ -92,7 +78,7 @@ public final class RedisStore extends AbstractLifecycle implements RedisStoreMan
     }
 
     RedisStore(JedisPool jedisPool, JmxSupport jmxSupport, PropertyChangeSupport propertyChangeSupport,
-               SessionSerializationUtils sessionSerializationUtils) {
+            SessionSerializationUtils sessionSerializationUtils) {
         this.jedisPool = jedisPool;
         this.jedisTemplate = new JedisTemplate(this.jedisPool);
         this.jmxSupport = jmxSupport;
@@ -524,40 +510,40 @@ public final class RedisStore extends AbstractLifecycle implements RedisStoreMan
     public void save(final Session session) {
         this.lockTemplate.withReadLock(new LockTemplate.LockedOperation<Void>() {
 
-                                           @Override
-                                           public Void invoke() {
-                                               final String sessionId = session.getId();
+            @Override
+            public Void invoke() {
+                final String sessionId = session.getId();
 
-                                               try {
-                                                   RedisStore.this.jedisTemplate.withJedis(new JedisTemplate.JedisOperation<Void>() {
+                try {
+                    RedisStore.this.jedisTemplate.withJedis(new JedisTemplate.JedisOperation<Void>() {
 
-                                                                                               @Override
-                                                                                               public Void invoke(Jedis jedis) {
-                                                                                                   try {
-                                                                                                       Transaction t = jedis.multi();
-                                                                                                       t.set(session.getId().getBytes(Protocol.CHARSET), RedisStore.this.sessionSerializationUtils
-                                                                                                               .serialize(session));
-                                                                                                       t.sadd(SESSIONS_KEY, sessionId);
-                                                                                                       t.exec();
-                                                                                                   } catch (IOException e) {
-                                                                                                       RedisStore.this.logger.log(SEVERE, String.format("Unable to save session %s",
-                                                                                                               sessionId), e);
-                                                                                                   }
+                        @Override
+                        public Void invoke(Jedis jedis) {
+                            try {
+                                Transaction t = jedis.multi();
+                                t.set(session.getId().getBytes(Protocol.CHARSET), RedisStore.this.sessionSerializationUtils
+                                        .serialize(session));
+                                t.sadd(SESSIONS_KEY, sessionId);
+                                t.exec();
+                            } catch (IOException e) {
+                                RedisStore.this.logger.log(SEVERE, String.format("Unable to save session %s",
+                                            sessionId), e);
+                            }
 
-                                                                                                   return null;
-                                                                                               }
+                            return null;
+                        }
 
-                                                                                           }
+                    }
 
-                                                   );
-                                               } catch (JedisConnectionException e) {
-                                                   RedisStore.this.logger.log(SEVERE, String.format("Unable to persist session %s", sessionId), e);
-                                               }
+                    );
+                } catch (JedisConnectionException e) {
+                    RedisStore.this.logger.log(SEVERE, String.format("Unable to persist session %s", sessionId), e);
+                }
 
-                                               return null;
-                                           }
+                return null;
+            }
 
-                                       }
+        }
 
         );
     }
@@ -627,7 +613,7 @@ public final class RedisStore extends AbstractLifecycle implements RedisStoreMan
 
     private void connect() {
         this.logger.info(String.format("Connecting to Redis Server at redis://%s:%d/%d", this.host, this.port,
-                this.database));
+                    this.database));
 
         this.jedisTemplate.withJedis(new JedisTemplate.JedisOperation<Void>() {
 

--- a/redis-store/src/main/java/com/gopivotal/manager/redis/RedisStore.java
+++ b/redis-store/src/main/java/com/gopivotal/manager/redis/RedisStore.java
@@ -454,15 +454,17 @@ public final class RedisStore extends AbstractLifecycle implements RedisStoreMan
                                 t.exec();
 
                                 return RedisStore.this.sessionSerializationUtils.deserialize(session.get());
-                            } catch (ClassNotFoundException e) {
-                                return logAndCreateEmptySession(id, e);
-                            } catch (IOException e) {
-                                return logAndCreateEmptySession(id, e);
+                            } catch (ClassNotFoundException | IOException e) {
+                                RedisStore.this.logger.log(SEVERE, String.format("Unable to load session %s. Empty " +
+                                            "session created.", id), e);
+                                return RedisStore.this.manager.createSession(id);
                             }
                         }
                     });
                 } catch (JedisConnectionException e) {
-                    session = logAndCreateEmptySession(id, e);
+                    RedisStore.this.logger.log(SEVERE, String.format("Unable to load session %s. Empty session " +
+                                "created.", id), e);
+                    session = RedisStore.this.manager.createSession(id);
                 }
 
                 return session;

--- a/redis-store/src/test/java/com/gopivotal/manager/redis/RedisStoreTest.java
+++ b/redis-store/src/test/java/com/gopivotal/manager/redis/RedisStoreTest.java
@@ -76,7 +76,7 @@ public final class RedisStoreTest {
 
     @Test
     public void clear() throws IOException {
-        Set<String> sessionIds = new HashSet<String>();
+        Set<String> sessionIds = new HashSet<>();
         sessionIds.add("test-id");
         when(this.jedis.smembers("sessions")).thenReturn(sessionIds);
 
@@ -117,7 +117,7 @@ public final class RedisStoreTest {
 
     @Test
     public void getSize() throws IOException {
-        Response<Long> response = new Response<Long>(BuilderFactory.LONG);
+        Response<Long> response = new Response<>(BuilderFactory.LONG);
         response.set((long) Integer.MAX_VALUE);
 
         when(this.transaction.scard("sessions")).thenReturn(response);
@@ -161,7 +161,7 @@ public final class RedisStoreTest {
 
     @Test
     public void keys() throws IOException {
-        Response<Set<String>> response = new Response<Set<String>>(BuilderFactory.STRING_SET);
+        Response<Set<String>> response = new Response<>(BuilderFactory.STRING_SET);
         response.set(Arrays.asList("test-id".getBytes(Protocol.CHARSET)));
 
         when(this.transaction.smembers("sessions")).thenReturn(response);
@@ -186,7 +186,7 @@ public final class RedisStoreTest {
         Session session = new StandardSession(this.manager);
         session.setId("test-id");
 
-        Response<byte[]> response = new Response<byte[]>(BuilderFactory.BYTE_ARRAY);
+        Response<byte[]> response = new Response<>(BuilderFactory.BYTE_ARRAY);
         response.set(this.sessionSerializationUtils.serialize(session));
 
         when(this.transaction.get("test-id".getBytes(Protocol.CHARSET))).thenReturn(response);


### PR DESCRIPTION
Each of these commits are intertwined with previous commits, so it didn't make sense to split these out into multiple PRs (even though four different things are occurring here).

Here, we:

- Cleanup some too-far-right code
- Undo previous commits downgrading code from Java 7 to Java 6 (bringing us back up to Java 7)
- Add a serialization fix for resolving classes (`protected Class<?> resolveClass(ObjectStreamClass desc)`)
- Add session class restoration fix using Tomcat 8+ style (`context.bind`)

These changes (hopefully) close/resolve/fix all open issues and PRs in the `session-managers` repository.

Note: the serialization changes need proper review from someone with actual Tomcat experience.  All tests pass, but these changes haven't been tested against live servers/applications.