### PR TITLE
Support user classes to be de-/serialized in the 1.2.x version 

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.gopivotal.manager</groupId>
         <artifactId>session-managers</artifactId>
-        <version>1.2.0.RELEASE</version>
+        <version>1.2.1.BUILD-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.gopivotal.manager</groupId>
         <artifactId>session-managers</artifactId>
-        <version>1.2.0.BUILD-SNAPSHOT</version>
+        <version>1.2.0.RELEASE</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
+++ b/common/src/main/java/com/gopivotal/manager/SessionSerializationUtils.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 
 /**
  * Utilities for serializing and deserializing {@link Session}s
@@ -61,7 +62,16 @@ public final class SessionSerializationUtils {
 
         try {
             bytes = new ByteArrayInputStream(session);
-            in = new ObjectInputStream(bytes);
+            in = new ObjectInputStream(bytes) {
+                @Override
+                protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+                    try {
+                        return Class.forName(desc.getName(), false, Thread.currentThread().getContextClassLoader());
+                    } catch (ClassNotFoundException cnfe) {
+                        return super.resolveClass(desc);
+                    }
+                }
+            };
 
             StandardSession standardSession = (StandardSession) this.manager.createEmptySession();
             standardSession.readObjectData(in);

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>com.gopivotal.manager</groupId>
     <artifactId>session-managers</artifactId>
-    <version>1.2.0.RELEASE</version>
+    <version>1.2.1.BUILD-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>com.gopivotal.manager</groupId>
     <artifactId>session-managers</artifactId>
-    <version>1.2.0.BUILD-SNAPSHOT</version>
+    <version>1.2.0.RELEASE</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/redis-store/pom.xml
+++ b/redis-store/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.gopivotal.manager</groupId>
         <artifactId>session-managers</artifactId>
-        <version>1.2.0.BUILD-SNAPSHOT</version>
+        <version>1.2.0.RELEASE</version>
     </parent>
 
     <artifactId>redis-store</artifactId>

--- a/redis-store/pom.xml
+++ b/redis-store/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.gopivotal.manager</groupId>
         <artifactId>session-managers</artifactId>
-        <version>1.2.0.RELEASE</version>
+        <version>1.2.1.BUILD-SNAPSHOT</version>
     </parent>
 
     <artifactId>redis-store</artifactId>


### PR DESCRIPTION
This branch is basically just a backport of 
14413c214ec5985f29893ca05d834a07bee2f467: Use current Thread classloader deserialization
to the 1.2.x version of the plugin.

I saw the recommendation of using spring-session or similar library for these cases (https://github.com/pivotalsoftware/session-managers/pull/6), but since this 
a) would cause the need to change a multitude of internal projects
and 
b) is already an integrated feature in master
I think this warrants the backport to the old version as well. 

There is currently no maintenance branch open for the 1.2.x versions, so not sure how to target the pull request. Hence I've changed the versioning to match the pattern, but cannot avoid the conflicts.