### PR TITLE
JUL replaced for SLF4J

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ This project contains implementations of the [Tomcat `PersistentManager` Store][
 ## Builds
 Each branch, release, and pull request kicks off builds on [Travis CI](https://travis-ci.org/pivotalsoftware/session-managers)
 
+## Logging
+This project uses [SLF4J][s] and defaults to Java Utils Logging (JUL) binding
+
+In case you want to use another one you must to package your binder and explicit remove the JUL dependency:
+
+```xml
+            <dependency>
+                <groupId>com.gopivotal.manager</groupId>
+                <artifactId>session-managers</artifactId>
+                <version>${session-managers.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-jdk14</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+```
+
 ## License
 This project is released under the [Apache License, Version 2.0][a].
 
@@ -18,3 +37,4 @@ This project is released under the [Apache License, Version 2.0][a].
 [c]: CONTRIBUTING.md
 [m]: http://tomcat.apache.org/tomcat-8.5-doc/config/manager.html
 [p]: https://help.github.com/categories/collaborating-with-issues-and-pull-requests/
+[s]: https://www.slf4j.org/manual.html

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/src/main/java/com/gopivotal/manager/LockTemplate.java
+++ b/common/src/main/java/com/gopivotal/manager/LockTemplate.java
@@ -16,12 +16,12 @@
 
 package com.gopivotal.manager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.SEVERE;
 
 /**
  * Utility methods that encapsulate {@link ReadWriteLock} idioms into closure-like methods.
@@ -29,7 +29,7 @@ import static java.util.logging.Level.SEVERE;
 @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
 public final class LockTemplate {
 
-    private final Logger logger = Logger.getLogger(this.getClass().getName());
+    private final Logger logger = LoggerFactory.getLogger(LockTemplate.class);
 
     private final ReadWriteLock monitor;
 
@@ -58,7 +58,7 @@ public final class LockTemplate {
         try {
             return operation.invoke();
         } catch (Exception e) {
-            this.logger.log(SEVERE, "Error while invoking read-locked operation", e);
+            this.logger.error("Error while invoking read-locked operation", e);
             throw new RuntimeException(e);
         } finally {
             lock.unlock();
@@ -79,7 +79,7 @@ public final class LockTemplate {
         try {
             return operation.invoke();
         } catch (Exception e) {
-            this.logger.log(SEVERE, "Error while invoking write-locked operation", e);
+            this.logger.error("Error while invoking write-locked operation", e);
             throw new RuntimeException(e);
         } finally {
             lock.unlock();

--- a/common/src/main/java/com/gopivotal/manager/StandardLifecycleSupport.java
+++ b/common/src/main/java/com/gopivotal/manager/StandardLifecycleSupport.java
@@ -19,18 +19,17 @@ package com.gopivotal.manager;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.WARNING;
 
 final class StandardLifecycleSupport implements LifecycleSupport {
 
     private final List<LifecycleListener> lifecycleListeners = new ArrayList<>();
 
-    private final Logger logger = Logger.getLogger(this.getClass().getName());
+    private final Logger logger = LoggerFactory.getLogger(StandardLifecycleSupport.class);
 
     private final Object monitor = new Object();
 
@@ -73,7 +72,7 @@ final class StandardLifecycleSupport implements LifecycleSupport {
             try {
                 lifecycleListener.lifecycleEvent(lifecycleEvent);
             } catch (RuntimeException e) {
-                this.logger.log(WARNING, "Exception encountered while notifying listener of lifecycle event", e);
+                this.logger.warn("Exception encountered while notifying listener of lifecycle event", e);
             }
         }
     }

--- a/common/src/main/java/com/gopivotal/manager/StandardPropertyChangeSupport.java
+++ b/common/src/main/java/com/gopivotal/manager/StandardPropertyChangeSupport.java
@@ -16,21 +16,20 @@
 
 package com.gopivotal.manager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.WARNING;
-
 
 /**
  * The standard implementation of the {@link PropertyChangeSupport} interface
  */
 public final class StandardPropertyChangeSupport implements PropertyChangeSupport {
 
-    private final Logger logger = Logger.getLogger(this.getClass().getName());
+    private final Logger logger = LoggerFactory.getLogger(StandardPropertyChangeSupport.class);
 
     private final Object monitor = new Object();
 
@@ -79,7 +78,7 @@ public final class StandardPropertyChangeSupport implements PropertyChangeSuppor
             try {
                 propertyChangeListener.propertyChange(propertyChangeEvent);
             } catch (RuntimeException e) {
-                this.logger.log(WARNING, "Exception encountered while notifying listener of property change", e);
+                this.logger.warn("Exception encountered while notifying listener of property change", e);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <junit.version>4.12</junit.version>
         <mockito.version>1.9.5</mockito.version>
         <tomcat.version>8.5.6</tomcat.version>
+        <slf4j.version>1.7.24</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -67,8 +68,21 @@
                 <artifactId>jedis</artifactId>
                 <version>${jedis.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
 

--- a/redis-store/pom.xml
+++ b/redis-store/pom.xml
@@ -60,6 +60,10 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
As stated at this issue:

#16

Remove all JUL usage and replace for SLF4J, allowing developers to use the log implementation they desire.