### PR TITLE
capture test logging output in file rather than stdout

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -74,10 +74,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 

--- a/common/src/test/resources/logging.properties
+++ b/common/src/test/resources/logging.properties
@@ -1,0 +1,4 @@
+handlers= java.util.logging.FileHandler
+java.util.logging.FileHandler.pattern = target/test.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.level=ALL

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
                     <version>2.16</version>
                     <configuration>
                         <runOrder>random</runOrder>
+                        <systemPropertyVariables>
+                            <java.util.logging.config.file>
+                                src/test/resources/logging.properties
+                            </java.util.logging.config.file>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/redis-store/pom.xml
+++ b/redis-store/pom.xml
@@ -121,10 +121,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 

--- a/redis-store/src/test/resources/logging.properties
+++ b/redis-store/src/test/resources/logging.properties
@@ -1,0 +1,4 @@
+handlers= java.util.logging.FileHandler
+java.util.logging.FileHandler.pattern = target/test.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.level=ALL


### PR DESCRIPTION
fixes #29 by capturing logging output in a local file (`target/test.log`)