### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ _Please refer back to this document as a checklist before issuing any pull reque
 ## Understanding the basics
 Not sure what a pull request is, or how to submit one?  Take a look at GitHub's excellent [help documentation][] first.
 
-[help documentation]: http://help.github.com/send-pull-requests
+[help documentation]: https://help.github.com/send-pull-requests
 
 ## Search GitHub Issues first; create an issue if necessary
 Is there already an issue that addresses your concern?  Do a bit of searching in our [GitHub issue tracker][] to see if you can find something similar. If not, please create a new issue before submitting a pull request unless the change is truly trivial, e.g. typo fixes, removing compiler warnings, etc.
@@ -66,7 +66,7 @@ then be sure to update it to 2014 appropriately
 ```
 
 ## Squash commits
-Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <http://git-scm.com/book/en/Git-Tools-Rewriting-History>.
+Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <https://git-scm.com/book/en/Git-Tools-Rewriting-History>.
 
 ## Use real name in git commits
 Please configure git to use your real first and last name for any commits you intend to submit as pull requests. For example, this is not acceptable:
@@ -131,7 +131,7 @@ Issue: #10, #11
 1. Mention associated GitHub issue(s) at the end of the commit comment, prefixed with "Issue: " as above
 1. In the body of the commit message, explain how things worked before this commit, what has changed, and how things work now
 
-[commit guidelines section of Pro Git]: http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
+[commit guidelines section of Pro Git]: https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
 
 ## Run all tests prior to submission
 See the [Running Tests][] section of the README for instructions. Make sure that all tests pass prior to submitting your pull request.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ This project is released under the [Apache License, Version 2.0][a].
 
 [a]: http://www.apache.org/licenses/LICENSE-2.0
 [c]: CONTRIBUTING.md
-[m]: http://tomcat.apache.org/tomcat-8.5-doc/config/manager.html
+[m]: https://tomcat.apache.org/tomcat-8.5-doc/config/manager.html
 [p]: https://help.github.com/categories/collaborating-with-issues-and-pull-requests/
 [s]: https://www.slf4j.org/manual.html

--- a/integrationTest/gradle.properties
+++ b/integrationTest/gradle.properties
@@ -6,5 +6,5 @@ logbackVersion=1.1.7
 slf4jVersion=1.7.25
 redisVersion=3.2
 
-tomcatDistfileMirror=http://apache.mirrors.pair.com/tomcat
+tomcatDistfileMirror=http://apache.mirrors.pair.com/tomcat/
 slf4jDistfileMirror=https://www.slf4j.org/dist

--- a/redis-store/README.md
+++ b/redis-store/README.md
@@ -103,4 +103,4 @@ Example: set the maximum number of concurrent connections to 20:
 </Context>
 ```
 
-[r]: http://redis.io
+[r]: https://redis.io


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.gopivotal.com.s3.amazonaws.com/release/ (200) with 1 occurrences could not be migrated:  
   ([https](https://maven.gopivotal.com.s3.amazonaws.com/release/) result SSLHandshakeException).
* http://maven.gopivotal.com.s3.amazonaws.com/release/com/gopivotal/manager/redis-store/1.2.0.RELEASE/redis-store-1.2.0.RELEASE.jar (200) with 1 occurrences could not be migrated:  
   ([https](https://maven.gopivotal.com.s3.amazonaws.com/release/com/gopivotal/manager/redis-store/1.2.0.RELEASE/redis-store-1.2.0.RELEASE.jar) result SSLHandshakeException).
* http://apache.mirrors.pair.com/tomcat (301) with 1 occurrences could not be migrated:  
   ([https](https://apache.mirrors.pair.com/tomcat) result NotSslRecordException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://redis.io with 1 occurrences migrated to:  
  https://redis.io ([https](https://redis.io) result 200).
* http://tomcat.apache.org/tomcat-8.5-doc/config/manager.html with 1 occurrences migrated to:  
  https://tomcat.apache.org/tomcat-8.5-doc/config/manager.html ([https](https://tomcat.apache.org/tomcat-8.5-doc/config/manager.html) result 200).
* http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 302).
* http://git-scm.com/book/en/Git-Tools-Rewriting-History with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Tools-Rewriting-History ([https](https://git-scm.com/book/en/Git-Tools-Rewriting-History) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences